### PR TITLE
Effect manager

### DIFF
--- a/pongstar.vcxproj
+++ b/pongstar.vcxproj
@@ -79,6 +79,7 @@
     <ClInclude Include="src\bumper.h" />
     <ClInclude Include="src\constants.h" />
     <ClInclude Include="src\dataManager.h" />
+    <ClInclude Include="src\effectManager.h" />
     <ClInclude Include="src\pickup.h" />
     <ClInclude Include="src\entity.h" />
     <ClInclude Include="src\font.h" />
@@ -97,6 +98,7 @@
     <ClCompile Include="src\ball.cpp" />
     <ClCompile Include="src\bumper.cpp" />
     <ClCompile Include="src\dataManager.cpp" />
+    <ClCompile Include="src\effectManager.cpp" />
     <ClCompile Include="src\pickup.cpp" />
     <ClCompile Include="src\entity.cpp" />
     <ClCompile Include="src\font.cpp" />

--- a/pongstar.vcxproj.filters
+++ b/pongstar.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClInclude Include="src\bumper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\effectManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\winmain.cpp">
@@ -120,6 +123,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\bumper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\effectManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/ball.cpp
+++ b/src/ball.cpp
@@ -52,8 +52,27 @@ void Ball::wallCollision() {
 	}
 }
 
-bool Ball::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
-	if (Entity::collidesWith(ent, collisionVector)) {
+void Ball::runEffects(EffectManager &effectManager) {
+	if (effectManager.getCurrentEffects(id).size() > 0) {
+		for (std::pair<effectNS::EFFECT_TYPE, float> currentEffect : effectManager.getCurrentEffects(id)) {
+			switch (currentEffect.first) {
+			case effectNS::ENLARGE:
+				float scale = 2.0f;
+
+				if (currentEffect.second == 0) {
+					scale = 1.0f;
+					effectManager.removeEffect(id, currentEffect.first);
+				}
+
+				spriteData.scale = scale;
+				break;
+			}
+		}
+	}
+}
+
+bool Ball::collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager) {
+	if (Entity::collidesWith(ent, collisionVector, effectManager)) {
 		switch (ent.getEntityType()) {
 		case entityNS::PADDLE:
 			Entity::paddleBounce(collisionVector, ent, ballNS::VELOCITY);

--- a/src/ball.cpp
+++ b/src/ball.cpp
@@ -5,7 +5,6 @@ std::random_device rd;     // only used once to initialise (seed) engine
 std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
 std::uniform_int_distribution<int> randomBool(0, 1);
 
-
 Ball::Ball() : Entity() {
 	entityType = entityNS::BALL;
 	spriteData.width = ballNS::WIDTH;
@@ -34,16 +33,16 @@ void Ball::update(float frameTime) {
 }
 
 void Ball::wallCollision() {
-	if (spriteData.x > GAME_WIDTH - ballNS::WIDTH) {
-		spriteData.x = GAME_WIDTH - ballNS::WIDTH;
+	if (spriteData.x > GAME_WIDTH - ballNS::WIDTH * spriteData.scale) {
+		spriteData.x = GAME_WIDTH - ballNS::WIDTH * spriteData.scale;
 		velocity.x = -velocity.x;
 	}
 	else if (spriteData.x < 0) {
 		spriteData.x = 0;
 		velocity.x = -velocity.x;
 	}
-	if (spriteData.y > GAME_HEIGHT - ballNS::HEIGHT) {
-		spriteData.y = GAME_HEIGHT - ballNS::HEIGHT;
+	if (spriteData.y > GAME_HEIGHT - ballNS::HEIGHT * spriteData.scale) {
+		spriteData.y = GAME_HEIGHT - ballNS::HEIGHT * spriteData.scale;
 		velocity.y = -velocity.y;
 	}
 	else if (spriteData.y < 0) {
@@ -75,8 +74,6 @@ bool Ball::collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &ef
 	if (Entity::collidesWith(ent, collisionVector, effectManager)) {
 		switch (ent.getEntityType()) {
 		case entityNS::PADDLE:
-			Entity::paddleBounce(collisionVector, ent, ballNS::VELOCITY);
-			break;
 		case entityNS::BUMPER:
 			Entity::paddleBounce(collisionVector, ent, ballNS::VELOCITY);
 			break;

--- a/src/ball.cpp
+++ b/src/ball.cpp
@@ -10,10 +10,10 @@ Ball::Ball() : Entity() {
 	entityType = entityNS::BALL;
 	spriteData.width = ballNS::WIDTH;
 	spriteData.height = ballNS::HEIGHT;
-	edge.top = -ballNS::HEIGHT * spriteData.scale / 2;
-	edge.bottom = ballNS::HEIGHT * spriteData.scale / 2;
-	edge.left = -ballNS::WIDTH * spriteData.scale / 2;
-	edge.right = ballNS::WIDTH * spriteData.scale / 2;
+	edge.top = -(long)(ballNS::HEIGHT * spriteData.scale / 2);
+	edge.bottom = (long)(ballNS::HEIGHT * spriteData.scale / 2);
+	edge.left = -(long)(ballNS::WIDTH * spriteData.scale / 2);
+	edge.right = (long)(ballNS::WIDTH * spriteData.scale / 2);
 }
 
 Ball::~Ball() {}

--- a/src/ball.h
+++ b/src/ball.h
@@ -18,7 +18,8 @@ public:
 
 	void update(float frameTime);
 	void wallCollision();
-	bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
+	void runEffects(EffectManager &effectManager);
+	bool collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager);
 };
 
 #endif

--- a/src/bumper.cpp
+++ b/src/bumper.cpp
@@ -1,5 +1,8 @@
 #include "bumper.h"
 
+// RNG
+
+
 Bumper::Bumper() : Entity() {
 	entityType = entityNS::BUMPER;
 	spriteData.width = bumperNS::WIDTH;
@@ -9,28 +12,44 @@ Bumper::Bumper() : Entity() {
 	edge.left = -(long)(bumperNS::WIDTH  * spriteData.scale / 2);
 	edge.right = (long)(bumperNS::WIDTH  * spriteData.scale / 2);
 	spriteData.scale = 0.5f;
+
+	std::random_device rd;     // only used once to initialise (seed) engine
+	std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+	std::uniform_int_distribution<int> randomBool(0, 1);
+	randomBumperX = std::uniform_int_distribution<int>(0, GAME_WIDTH / 4 - spriteData.width * spriteData.scale);
+	randomBumperY = std::uniform_int_distribution<int>(0, GAME_HEIGHT - spriteData.height * spriteData.scale);
+
+	float xCoord = randomBool(rng) == 0 ? randomBumperX(rng) + GAME_WIDTH / 2 : randomBumperX(rng) + GAME_WIDTH / 4;
+
+	setX(xCoord);
+	setY(randomBumperY(rng));
 }
 
 Bumper::~Bumper() {}
 
-bool Bumper::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
-	// RNG
-	std::random_device rd;     // only used once to initialise (seed) engine
-	std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
-	std::uniform_int_distribution<int> randomBumperX(0, GAME_WIDTH / 4 - spriteData.width * spriteData.scale);
-	std::uniform_int_distribution<int> randomBumperY(0, GAME_HEIGHT - spriteData.height * spriteData.scale);
-
-	if (Entity::collidesWith(ent, collisionVector)) {
+bool Bumper::collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager) {
+	if (Entity::collidesWith(ent, collisionVector, effectManager)) {
 		switch (ent.getEntityType()) {
 		case entityNS::BALL:
-			if (getX() < GAME_WIDTH / 2)
-				setX(randomBumperX(rng) + GAME_WIDTH / 2);
-			else
-				setX(randomBumperX(rng) + GAME_WIDTH / 4);
-			setY(randomBumperY(rng));
+			randomLocationBumper();
 			break;
 		}
 	}
 
 	return true;
+}
+
+void Bumper::randomLocationBumper() {
+	std::random_device rd;     // only used once to initialise (seed) engine
+	std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+
+	float xCoord;
+
+	if (getX() < GAME_WIDTH / 2)
+		xCoord = randomBumperX(rng) + GAME_WIDTH / 2;
+	else
+		xCoord = randomBumperX(rng) + GAME_WIDTH / 4;
+
+	setX(xCoord);
+	setY(randomBumperY(rng));
 }

--- a/src/bumper.h
+++ b/src/bumper.h
@@ -11,11 +11,15 @@ namespace bumperNS {
 
 class Bumper : public Entity {
 private:
+	std::uniform_int_distribution<int> randomBumperX;
+	std::uniform_int_distribution<int> randomBumperY;
+
 public:
 	Bumper();
 	~Bumper();
 
-	bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
+	bool collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager);
+	void randomLocationBumper();
 };
 
 #endif

--- a/src/effectManager.cpp
+++ b/src/effectManager.cpp
@@ -1,0 +1,46 @@
+#include "effectManager.h"
+
+EffectManager::EffectManager() {}
+
+EffectManager::~EffectManager() {}
+
+// Decrement duration of all currect effects
+void EffectManager::update(float frameTime) {
+	// Loop through all entities with effects
+	for (std::pair<int, std::unordered_map<effectNS::EFFECT_TYPE, float>> entity : entityEffects) {
+		// Loop through all effects of current entity
+		for (std::pair<effectNS::EFFECT_TYPE, float> currentEffect : entity.second) {
+			float newDuration = currentEffect.second - frameTime;
+
+			// Update duration and set to 0 once duration has expired
+			entityEffects[entity.first][currentEffect.first] = (newDuration <= 0) ? 0 : newDuration;
+		}
+	}
+}
+
+// Add new effect
+void EffectManager::addEffect(int entityId, effectNS::EFFECT_TYPE effectType, float duration) {
+	if (entityEffects.count(entityId) == 0) {
+		std::unordered_map<effectNS::EFFECT_TYPE, float> currentEffects = {};
+		entityEffects.insert({ entityId, currentEffects });
+	}
+
+	entityEffects[entityId].insert({ effectType, duration });
+}
+
+// Remove an effect
+void EffectManager::removeEffect(int entityId, effectNS::EFFECT_TYPE effectType) {
+	// Remove effect from entity
+	entityEffects[entityId].erase(effectType);
+}
+
+// Returns all current effects the entity has
+std::unordered_map<effectNS::EFFECT_TYPE, float> EffectManager::getCurrentEffects(int entityId) {
+	std::unordered_map<effectNS::EFFECT_TYPE, float> currentEffects = {};
+
+	if (entityEffects.count(entityId) != 0) {
+		currentEffects = entityEffects[entityId];
+	}
+
+	return currentEffects;
+}

--- a/src/effectManager.h
+++ b/src/effectManager.h
@@ -1,0 +1,33 @@
+#ifndef _EFFECTMANAGER_H
+#define _EFFECTMANAGER_H
+
+#include <unordered_map>
+
+namespace effectNS {
+	const enum EFFECT_TYPE { MAGNET, INVERT, ENLARGE };
+
+	struct EffectData {
+		effectNS::EFFECT_TYPE effectType;
+		int frame;
+		float duration;
+
+		EffectData() {}
+		EffectData(effectNS::EFFECT_TYPE et, int f, float d) : effectType(et), frame(f), duration(d) {}
+	};
+}
+
+class EffectManager {
+private:
+	std::unordered_map<int, std::unordered_map<effectNS::EFFECT_TYPE, float>> entityEffects;
+
+public:
+	EffectManager();
+	~EffectManager();
+
+	void update(float frameTime);
+	void addEffect(int entityId, effectNS::EFFECT_TYPE effectType, float duration);
+	void removeEffect(int entityId, effectNS::EFFECT_TYPE effectType);
+	std::unordered_map<effectNS::EFFECT_TYPE, float> getCurrentEffects(int entityId);
+};
+
+#endif

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -78,7 +78,7 @@ void Entity::ai(float frameTime, Entity &ent) {}
 // Post: returns true if collision, false otherwise
 //       sets collisionVector if collision
 //=============================================================================
-bool Entity::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
+bool Entity::collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager) {
 	// if either entity is not active then no collision may occcur
 	if (!active || !ent.getActive())
 		return false;
@@ -434,3 +434,5 @@ void Entity::gravityForce(Entity *ent, float frameTime) {
 	// Add gravity vector to moving velocity vector to change direction
 	velocity += gravityV;
 }
+
+void Entity::runEffects(EffectManager &effectManager) {}

--- a/src/entity.h
+++ b/src/entity.h
@@ -2,10 +2,12 @@
 #define _ENTITY_H
 #define WIN32_LEAN_AND_MEAN
 
+#include <random>
+
 #include "image.h"
 #include "input.h"
 #include "game.h"
-#include <random>
+#include "effectManager.h"
 
 namespace entityNS {
 	enum ENTITY_TYPE { BALL, PADDLE, PICKUP, BUMPER };
@@ -173,7 +175,7 @@ public:
 	virtual bool outsideRect(RECT rect);
 
 	// Does this entity collide with ent?
-	virtual bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
+	virtual bool collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager);
 
 	// Entity bounces after collision with other Entity
 	void bounce(VECTOR2 &collisionVector, Entity &ent);
@@ -182,6 +184,8 @@ public:
 
 	// Adds the gravitational force to the velocity vector of this entity
 	void gravityForce(Entity *other, float frameTime);
+
+	virtual void runEffects(EffectManager& effectManager);
 };
 
 #endif

--- a/src/paddle.cpp
+++ b/src/paddle.cpp
@@ -40,8 +40,8 @@ void Paddle::update(float frameTime) {
 }
 
 
-bool Paddle::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
-	if (Entity::collidesWith(ent, collisionVector)) {
+bool Paddle::collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager) {
+	if (Entity::collidesWith(ent, collisionVector, effectManager)) {
 		switch (ent.getEntityType()) {
 			
 		}

--- a/src/paddle.cpp
+++ b/src/paddle.cpp
@@ -6,10 +6,10 @@ Paddle::Paddle(PaddleControls pc) : Entity() {
 	entityType = entityNS::PADDLE;
 	spriteData.width = paddleNS::WIDTH;
 	spriteData.height = paddleNS::HEIGHT;
-	edge.top = -paddleNS::HEIGHT * spriteData.scale / 2;
-	edge.bottom = paddleNS::HEIGHT * spriteData.scale / 2;
-	edge.left = -paddleNS::WIDTH * spriteData.scale / 2;
-	edge.right = paddleNS::WIDTH * spriteData.scale / 2;
+	edge.top = -(long)(paddleNS::HEIGHT * spriteData.scale / 2);
+	edge.bottom = (long)(paddleNS::HEIGHT * spriteData.scale / 2);
+	edge.left = -(long)(paddleNS::WIDTH * spriteData.scale / 2);
+	edge.right = (long)(paddleNS::WIDTH * spriteData.scale / 2);
 
 	controls = pc;
 }

--- a/src/paddle.h
+++ b/src/paddle.h
@@ -22,7 +22,7 @@ public:
 	~Paddle();
 
 	void update(float frameTime);
-	bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
+	bool collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager);
 };
 
 #endif

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -24,8 +24,8 @@ Pickup::~Pickup() {}
 
 void Pickup::update(float frameTime) {}
 
-bool Pickup::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
-	if (Entity::collidesWith(ent, collisionVector)) {
+bool Pickup::collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager) {
+	if (Entity::collidesWith(ent, collisionVector, effectManager)) {
 		switch (ent.getEntityType()) {
 		case entityNS::BALL:
 			setActive(false);
@@ -37,6 +37,11 @@ bool Pickup::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
 
 			case effectNS::INVERT:
 				printf("invert\n");
+				break;
+
+			case effectNS::ENLARGE:
+				printf("enlarge\n");
+				effectManager.addEffect(ent.getId(), effectType, duration);
 				break;
 			}
 			break;

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -11,10 +11,10 @@ Pickup::Pickup(effectNS::EFFECT_TYPE et, int f, float d) : Entity() {
 	spriteData.scale = pickupNS::SCALE;
 	spriteData.width = pickupNS::WIDTH;
 	spriteData.height = pickupNS::HEIGHT;
-	edge.top = -pickupNS::HEIGHT * spriteData.scale / 2;
-	edge.bottom = pickupNS::HEIGHT * spriteData.scale / 2;
-	edge.left = -pickupNS::WIDTH * spriteData.scale / 2;
-	edge.right = pickupNS::WIDTH * spriteData.scale / 2;
+	edge.top = -(long)(pickupNS::HEIGHT * spriteData.scale / 2);
+	edge.bottom = (long)(pickupNS::HEIGHT * spriteData.scale / 2);
+	edge.left = -(long)(pickupNS::WIDTH * spriteData.scale / 2);
+	edge.right = (long)(pickupNS::WIDTH * spriteData.scale / 2);
 
 	currentFrame = f;
 	loop = false; 

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -1,8 +1,6 @@
 #ifndef _PICKUP_H
 #define _PICKUP_H
 
-#include <unordered_map>
-
 #include "entity.h"
 
 namespace pickupNS {
@@ -11,19 +9,6 @@ namespace pickupNS {
 	const int NCOLS = 9;
 	const float VELOCITY = 1000.0f;
 	const float SCALE = 0.4f;
-}
-
-namespace effectNS {
-	const enum EFFECT_TYPE { MAGNET, INVERT };
-
-	struct EffectData {
-		effectNS::EFFECT_TYPE effectType;
-		int frame;
-		float duration;
-
-		EffectData() {}
-		EffectData(effectNS::EFFECT_TYPE et, int f, float d) : effectType(et), frame(f), duration(d) {}
-	};
 }
 
 class Pickup : public Entity {
@@ -46,7 +31,7 @@ public:
 	void setDuration(float d) { duration = d; }
 
 	void update(float frameTime);
-	bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
+	bool collidesWith(Entity &ent, VECTOR2 &collisionVector, EffectManager &effectManager);
 };
 
 #endif

--- a/src/pickupManager.cpp
+++ b/src/pickupManager.cpp
@@ -14,12 +14,16 @@ Pickup* PickupManager::randomPickup(Game* game) {
 	std::random_device rd;     // only used once to initialise (seed) engine
 	std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
 	std::uniform_int_distribution<int> randomInt(0, effectDataNS::EFFECT_ARR_SIZE);
+	std::uniform_int_distribution<int> randomYcoord(0, GAME_HEIGHT - (int)(pickupNS::HEIGHT * pickupNS::SCALE));
 
 	effectNS::EffectData data = effectDataNS::effectArray[randomInt(rng)];
 	Pickup* pickup = new Pickup(data.effectType, data.frame, data.duration);
 
 	if (!pickup->initialize(game, pickupNS::WIDTH, pickupNS::HEIGHT, pickupNS::NCOLS, &pickupTexture))
 		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing pickup"));
+
+	pickup->setX(GAME_WIDTH / 2 - (pickupNS::WIDTH * pickupNS::SCALE) / 2);
+	pickup->setY((float)randomYcoord(rng));
 
 	return pickup;
 }

--- a/src/pickupManager.cpp
+++ b/src/pickupManager.cpp
@@ -16,14 +16,18 @@ Pickup* PickupManager::randomPickup(Game* game) {
 	std::uniform_int_distribution<int> randomInt(0, effectDataNS::EFFECT_ARR_SIZE);
 	std::uniform_int_distribution<int> randomYcoord(0, GAME_HEIGHT - (int)(pickupNS::HEIGHT * pickupNS::SCALE));
 
-	effectNS::EffectData data = effectDataNS::effectArray[randomInt(rng)];
+	//effectNS::EffectData data = effectDataNS::effectArray[randomInt(rng)];
+	effectNS::EffectData data = effectDataNS::effectArray[2];
 	Pickup* pickup = new Pickup(data.effectType, data.frame, data.duration);
 
 	if (!pickup->initialize(game, pickupNS::WIDTH, pickupNS::HEIGHT, pickupNS::NCOLS, &pickupTexture))
 		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing pickup"));
 
-	pickup->setX(GAME_WIDTH / 2 - (pickupNS::WIDTH * pickupNS::SCALE) / 2);
-	pickup->setY((float)randomYcoord(rng));
+	/*pickup->setX(GAME_WIDTH / 2 - (pickupNS::WIDTH * pickupNS::SCALE) / 2);
+	pickup->setY((float)randomYcoord(rng));*/
+
+	pickup->setX(GAME_WIDTH / 4);
+	pickup->setY(GAME_HEIGHT / 2 - (pickupNS::HEIGHT * pickupNS::SCALE) / 2);
 
 	return pickup;
 }

--- a/src/pickupManager.h
+++ b/src/pickupManager.h
@@ -1,7 +1,6 @@
 #ifndef _PICKUPMANAGER_H
 #define _PICKUPMANAGER_H
 
-#include <unordered_map>
 #include <vector>
 #include <string>
 #include <random>
@@ -16,7 +15,8 @@
 namespace effectDataNS {
 	const effectNS::EffectData effectArray[] = {
 		effectNS::EffectData(effectNS::MAGNET, 0, 1.0f),
-		effectNS::EffectData(effectNS::INVERT, 1, 1.0f)
+		effectNS::EffectData(effectNS::INVERT, 1, 1.0f),
+		effectNS::EffectData(effectNS::ENLARGE, 7, 5.0f)
 	};
 
 	const int EFFECT_ARR_SIZE = 2;

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -99,10 +99,14 @@ void Pongstar::initializeEntities() {
 	// randomly generate basic set of pickups
 	Pickup* pickup = pickupManager->randomPickup(this);
 
+<<<<<<< HEAD
 	pickup->setX(GAME_WIDTH / 4);
 	pickup->setY(GAME_HEIGHT / 2 - (pickupNS::HEIGHT * pickupNS::SCALE) / 2);
 
 	//entityVector.push_back(pickup);
+=======
+	entityVector.push_back(pickup);
+>>>>>>> Make pickup spawn at a random location along the middle
 }
 
 //=============================================================================

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -56,12 +56,6 @@ void Pongstar::initialize(HWND hwnd) {
 }
 
 void Pongstar::initializeEntities() {
-	// RNG
-	std::random_device rd;     // only used once to initialise (seed) engine
-	std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
-	std::uniform_int_distribution<int> randomBumperX(0, 240);
-	std::uniform_int_distribution<int> randomBumperY(0, 640);
-
 	ControlsJson controls = dataManager->getControlsJson();
 
 	Paddle* paddle1 = new Paddle(controls.p1);
@@ -89,10 +83,6 @@ void Pongstar::initializeEntities() {
 	ball->setX(GAME_WIDTH / 2 - ballNS::WIDTH / 2);
 	ball->setY(GAME_HEIGHT / 2 - ballNS::HEIGHT / 2);
 
-	
-	bumper->setX(randomBumperX(rng) + GAME_WIDTH / 4);
-	bumper->setY(randomBumperY(rng));
-
 	entityVector.push_back(paddle1);
 	entityVector.push_back(paddle2);
 	entityVector.push_back(ball);
@@ -101,14 +91,7 @@ void Pongstar::initializeEntities() {
 	// randomly generate basic set of pickups
 	Pickup* pickup = pickupManager->randomPickup(this);
 
-<<<<<<< HEAD
-	pickup->setX(GAME_WIDTH / 4);
-	pickup->setY(GAME_HEIGHT / 2 - (pickupNS::HEIGHT * pickupNS::SCALE) / 2);
-
-	//entityVector.push_back(pickup);
-=======
 	entityVector.push_back(pickup);
->>>>>>> Make pickup spawn at a random location along the middle
 }
 
 //=============================================================================

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -31,6 +31,8 @@ void Pongstar::initialize(HWND hwnd) {
 
 	pickupManager = new PickupManager(graphics);
 
+	effectManager = new EffectManager();
+
 	// Textures
 	if (!dividerTexture.initialize(graphics, DIVIDER_IMAGE))
 		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing divider texture"));
@@ -113,8 +115,11 @@ void Pongstar::initializeEntities() {
 // Update all game items
 //=============================================================================
 void Pongstar::update() {
+	effectManager->update(frameTime);
+
 	for (size_t i = 0; i < entityVector.size(); ++i) {
 		entityVector[i]->update(frameTime);
+		entityVector[i]->runEffects(*effectManager);
 
 		if (!entityVector[i]->getActive()) {
 			deleteEntityQueue.push(i);
@@ -152,7 +157,7 @@ void Pongstar::collisions() {
 	for (size_t i = 0; i < entityVector.size(); ++i) {
 		for (size_t j = 0; j < entityVector.size(); ++j) {
 			if (entityVector[i]->getId() != entityVector[j]->getId()) {
-				entityVector[i]->collidesWith(*entityVector[j], collisionVector);
+				entityVector[i]->collidesWith(*entityVector[j], collisionVector, *effectManager);
 			}
 		}
 	}

--- a/src/pongstar.h
+++ b/src/pongstar.h
@@ -8,10 +8,12 @@
 #include <chrono>
 
 #include "game.h"
-#include "textureManager.h"
 #include "dataManager.h"
 #include "fontManager.h"
 #include "pickupManager.h"
+#include "effectManager.h"
+#include "textureManager.h"
+
 #include "image.h"
 
 #include "paddle.h"
@@ -26,6 +28,7 @@ private:
 	DataManager* dataManager;
 	FontManager* fontManager;
 	PickupManager* pickupManager;
+	EffectManager* effectManager;
 
 	TextureManager dividerTexture;
 	TextureManager paddleTexture;


### PR DESCRIPTION
Here's my implementation of how to manage cross-entity comms. Let me know what you guys think. 

If you're a little confused here's an example of how `entityEffects` would look like
```c++
std::unordered_map<int, std::unordered_map<effectNS::EFFECT_TYPE, float>> entityEffects = {
  { 0, { { effectNS::ENLARGE, 1.0f }, { effectNS::INVERT, 0.2f } } },
  { 1, { { effectNS::MAGNET, 2.4f } } }
};

// Outer unordered_map
// Key: Entity ID
// Value: inner unordered_map

// Inner unordered_map
// Key: effect enum
// Value: Remaining duration for that effect
```

Don't have to merge this yet. I'm just showing how I did it. Open to suggestions or better implementations.