### PR TITLE
Spawn pickups on ball-bumper collision

### DIFF
--- a/src/bumper.cpp
+++ b/src/bumper.cpp
@@ -1,8 +1,5 @@
 #include "bumper.h"
 
-// RNG
-
-
 Bumper::Bumper() : Entity() {
 	entityType = entityNS::BUMPER;
 	spriteData.width = bumperNS::WIDTH;
@@ -19,7 +16,18 @@ Bumper::Bumper() : Entity() {
 	randomBumperX = std::uniform_int_distribution<int>(0, GAME_WIDTH / 4 - spriteData.width * spriteData.scale);
 	randomBumperY = std::uniform_int_distribution<int>(0, GAME_HEIGHT - spriteData.height * spriteData.scale);
 
-	float xCoord = randomBool(rng) == 0 ? randomBumperX(rng) + GAME_WIDTH / 2 : randomBumperX(rng) + GAME_WIDTH / 4;
+	float xCoord = randomBumperX(rng);
+
+	if (randomBool(rng) == 0) {
+		// Spawn bumper on right side;
+		xCoord += GAME_WIDTH / 2;
+		side = bumperNS::RIGHT;
+	}
+	else {
+		// Spawn bumper on left side
+		xCoord += GAME_WIDTH / 4;
+		side = bumperNS::LEFT;
+	}
 
 	setX(xCoord);
 	setY(randomBumperY(rng));
@@ -28,9 +36,17 @@ Bumper::Bumper() : Entity() {
 Bumper::~Bumper() {}
 
 bool Bumper::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
+	Message* msgPtr = NULL;
+
 	if (Entity::collidesWith(ent, collisionVector)) {
 		switch (ent.getEntityType()) {
 		case entityNS::BALL:
+			// Set message to spawn pickup
+			messageNS::PICKUP_CMD direction = (side == bumperNS::LEFT) ? messageNS::MOVE_RIGHT : messageNS::MOVE_LEFT;
+			msgPtr = new Message(messageNS::PICKUP, direction);
+			setMessage(msgPtr);
+
+			// Move bumper
 			randomLocationBumper();
 			break;
 		}
@@ -43,12 +59,18 @@ void Bumper::randomLocationBumper() {
 	std::random_device rd;     // only used once to initialise (seed) engine
 	std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
 
-	float xCoord;
+	float xCoord = randomBumperX(rng);
 
-	if (getX() < GAME_WIDTH / 2)
-		xCoord = randomBumperX(rng) + GAME_WIDTH / 2;
-	else
-		xCoord = randomBumperX(rng) + GAME_WIDTH / 4;
+	if (side == bumperNS::LEFT) {
+		// Spawn bumper on right side;
+		xCoord += GAME_WIDTH / 2;
+		side = bumperNS::RIGHT;
+	}
+	else {
+		// Spawn bumper on left side
+		xCoord += GAME_WIDTH / 4;
+		side = bumperNS::LEFT;
+	}
 
 	setX(xCoord);
 	setY(randomBumperY(rng));

--- a/src/bumper.h
+++ b/src/bumper.h
@@ -7,16 +7,21 @@ namespace bumperNS {
 	const int HEIGHT = 200;
 	const int WIDTH = 200;
 	const int NCOLS = 1;
+	const enum SIDE { LEFT, RIGHT };
 }
 
 class Bumper : public Entity {
 private:
 	std::uniform_int_distribution<int> randomBumperX;
 	std::uniform_int_distribution<int> randomBumperY;
+	bumperNS::SIDE side;
 
 public:
 	Bumper();
 	~Bumper();
+
+	bumperNS::SIDE getSide() { return side; }
+	void setSide(bumperNS::SIDE s) { side = s; }
 
 	bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
 	void randomLocationBumper();

--- a/src/effectManager.h
+++ b/src/effectManager.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 
 namespace effectNS {
-	const enum EFFECT_TYPE { MAGNET, INVERT, ENLARGE };
+	const enum EFFECT_TYPE { MAGNET, INVERT, SHIELD, MULTIPLY, BOOST, SLOW, SHRINK, ENLARGE, MYSTERY };
 
 	struct EffectData {
 		effectNS::EFFECT_TYPE effectType;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -2,14 +2,20 @@
 
 Message::Message() {}
 
-// generic constructor for any messages
+// constructor for pickup messages
+Message::Message(messageNS::MESSAGE_TYPE mt, messageNS::PICKUP_CMD pc) {
+	messageType = mt;
+	pickupCmd = pc;
+}
+
+// constructor for score messages
 Message::Message(messageNS::MESSAGE_TYPE mt, messageNS::TARGET_TYPE tt, messageNS::SCORE_CMD sc) {
 	messageType = mt;
 	targetType = tt;
 	scoreCmd = sc;
 }
 
-// constructor for effects
+// constructor for effects messages
 Message::Message(messageNS::MESSAGE_TYPE mt, messageNS::TARGET_TYPE tt, effectNS::EFFECT_TYPE et, float d) {
 	messageType = mt;
 	targetType = tt;

--- a/src/message.h
+++ b/src/message.h
@@ -4,9 +4,10 @@
 #include "effectManager.h"
 
 namespace messageNS {
-	enum MESSAGE_TYPE { SCORE, EFFECT };
+	enum MESSAGE_TYPE { SCORE, EFFECT, PICKUP };
 	enum TARGET_TYPE { LEFT_P, RIGHT_P, ALL_P, BALL };
 	enum SCORE_CMD { INCREMENT };
+	enum PICKUP_CMD { MOVE_LEFT, MOVE_RIGHT };
 }
 
 class Message {
@@ -14,26 +15,32 @@ private:
 	messageNS::MESSAGE_TYPE messageType;
 	messageNS::TARGET_TYPE targetType;
 	messageNS::SCORE_CMD scoreCmd;
+	messageNS::PICKUP_CMD pickupCmd;
 
 	effectNS::EFFECT_TYPE effectType;
 	float duration;
 
 public:
-	Message();	
+	Message();
+	Message(messageNS::MESSAGE_TYPE mt, messageNS::PICKUP_CMD pc); // pickup
 	Message(messageNS::MESSAGE_TYPE mt, messageNS::TARGET_TYPE tt, messageNS::SCORE_CMD sc); // score
 	Message(messageNS::MESSAGE_TYPE mt, messageNS::TARGET_TYPE tt, effectNS::EFFECT_TYPE et, float duration); // effect
 
 	~Message();
 
+	// Getters
 	messageNS::MESSAGE_TYPE getMessageType() { return messageType; }
 	messageNS::TARGET_TYPE getTargetType() { return targetType; }
 	messageNS::SCORE_CMD getScoreCmd() { return scoreCmd; }
+	messageNS::PICKUP_CMD getPickupCmd() { return pickupCmd; }
 	effectNS::EFFECT_TYPE getEffectType() { return effectType; }
 	float getDuration() { return duration; }
 
+	// Setters
 	void setMessageType(messageNS::MESSAGE_TYPE mt) { messageType = mt; }
 	void setTargetType(messageNS::TARGET_TYPE tt) { targetType = tt; }
 	void setScoreCmd(messageNS::SCORE_CMD sc) { scoreCmd = sc; }
+	void setPickupCmd(messageNS::PICKUP_CMD pc) { pickupCmd = pc; }
 	void setEffectType(effectNS::EFFECT_TYPE et) { effectType = et; }
 	void setDuration(float d) { duration = d; }
 };

--- a/src/messageManager.cpp
+++ b/src/messageManager.cpp
@@ -2,8 +2,11 @@
 
 MessageManager::MessageManager() {}
 
-MessageManager::MessageManager(std::vector<Entity*>* ev) {
+MessageManager::MessageManager(Game* g, Graphics* graphics, std::vector<Entity*>* ev) {
+	game = g;
 	entityVector = ev;
+
+	pickupManager = new PickupManager(graphics);
 }
 
 MessageManager::~MessageManager() {}
@@ -54,6 +57,9 @@ void MessageManager::dispatch(Message* msg) {
 		case messageNS::EFFECT: {
 			dispatchEffect(msg);
 		} break;
+		case messageNS::PICKUP: {
+			dispatchPickup(msg);
+		}
 	}
 }
 
@@ -66,10 +72,23 @@ void MessageManager::dispatchScore(Message* msg) {
 	}
 }
 
-void MessageManager::dispatchEffect(Message *msg) {
+void MessageManager::dispatchEffect(Message* msg) {
 	switch (msg->getTargetType()) {
 		case messageNS::BALL: {
 			getBall()->triggerEffect(msg->getEffectType(), msg->getDuration());
 		} break;
 	}
+}
+
+void MessageManager::dispatchPickup(Message* msg) {
+	Pickup* pickup = pickupManager->randomPickup(game);
+
+	if (msg->getPickupCmd() == messageNS::MOVE_LEFT) {
+		pickup->setVelocity(VECTOR2(-pickupNS::VELOCITY, 0));
+	}
+	else {
+		pickup->setVelocity(VECTOR2(pickupNS::VELOCITY, 0));
+	}
+
+	entityVector->push_back(pickup);
 }

--- a/src/messageManager.h
+++ b/src/messageManager.h
@@ -5,26 +5,31 @@
 
 #include <queue>
 
+#include "game.h"
 #include "message.h"
 #include "entity.h"
 #include "paddle.h"
 #include "ball.h"
+#include "pickupManager.h"
 
 class MessageManager {
 private:
+	Game* game;
+	PickupManager* pickupManager;
 	std::queue<Message*> messageQueue;
 	std::vector<Entity*>* entityVector;
 
 public:
 	MessageManager();
-	MessageManager(std::vector<Entity*>* ev);
+	MessageManager(Game* g, Graphics* graphics, std::vector<Entity*>* ev);
 	~MessageManager();
 
 	void push(Message* msg);
 	void dispatch(Message* msg);
 
-	void dispatchScore(Message *msg);
-	void dispatchEffect(Message *msg);
+	void dispatchScore(Message* msg);
+	void dispatchEffect(Message* msg);
+	void dispatchPickup(Message* msg);
 
 	void resolve();
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -22,7 +22,14 @@ Pickup::Pickup(effectNS::EFFECT_TYPE et, int f, float d) : Entity() {
 
 Pickup::~Pickup() {}
 
-void Pickup::update(float frameTime) {}
+void Pickup::update(float frameTime) {
+	Entity::update(frameTime);
+
+	spriteData.x += frameTime * velocity.x;
+	spriteData.y += frameTime * velocity.y;
+
+	checkWithinView();
+}
 
 bool Pickup::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
 	Message* msgPtr = NULL;
@@ -38,4 +45,10 @@ bool Pickup::collidesWith(Entity &ent, VECTOR2 &collisionVector) {
 	}
 
 	return true;
+}
+
+void Pickup::checkWithinView() {
+	if (spriteData.x < -spriteData.width * spriteData.scale || spriteData.x > GAME_WIDTH) {
+		setActive(false);
+	}
 }

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -7,7 +7,7 @@ namespace pickupNS {
 	const int HEIGHT = 100;
 	const int WIDTH = 100;
 	const int NCOLS = 9;
-	const float VELOCITY = 1000.0f;
+	const float VELOCITY = 100.0f;
 	const float SCALE = 0.4f;
 }
 
@@ -32,6 +32,8 @@ public:
 
 	void update(float frameTime);
 	bool collidesWith(Entity &ent, VECTOR2 &collisionVector);
+
+	void checkWithinView();
 };
 
 #endif

--- a/src/pickupManager.h
+++ b/src/pickupManager.h
@@ -5,26 +5,33 @@
 #include <string>
 #include <random>
 
+#include "game.h"
 #include "graphics.h"
 #include "gameError.h"
 #include "textureManager.h"
 #include "pickup.h"
-#include "game.h"
 
 namespace effectDataNS {
 	const effectNS::EffectData effectArray[] = {
 		effectNS::EffectData(effectNS::MAGNET, 0, 1.0f),
 		effectNS::EffectData(effectNS::INVERT, 1, 1.0f),
-		effectNS::EffectData(effectNS::ENLARGE, 7, 2.0f)
+		effectNS::EffectData(effectNS::SHIELD, 2, 1.0f),
+		effectNS::EffectData(effectNS::MULTIPLY, 3, 1.0f),
+		effectNS::EffectData(effectNS::BOOST, 4, 1.0f),
+		effectNS::EffectData(effectNS::SLOW, 5, 1.0f),
+		effectNS::EffectData(effectNS::SHRINK, 6, 1.0f),
+		effectNS::EffectData(effectNS::ENLARGE, 7, 3.0f),
+		effectNS::EffectData(effectNS::MYSTERY, 8, 1.0f)
 	};
 
-	const int EFFECT_ARR_SIZE = 3;
+	const int EFFECT_ARR_SIZE = 9;
 }
 
 
 class PickupManager {
 private:
 	TextureManager pickupTexture;
+
 public:
 	PickupManager();
 	PickupManager(Graphics* graphics);

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -29,9 +29,7 @@ void Pongstar::initialize(HWND hwnd) {
 	fontManager = new FontManager(graphics);
 	fontManager->initialize();
 
-	pickupManager = new PickupManager(graphics);
-
-	messageManager = new MessageManager(&entityVector);
+	messageManager = new MessageManager(this, graphics, &entityVector);
 
 	// Textures
 	if (!dividerTexture.initialize(graphics, DIVIDER_IMAGE))
@@ -87,12 +85,6 @@ void Pongstar::initializeEntities() {
 	entityVector.push_back(paddle2);
 	entityVector.push_back(ball);
 	entityVector.push_back(bumper);
-
-	// randomly generate basic set of pickups
-	//Pickup* pickup = pickupManager->randomPickup(this);
-	Pickup* pickup = pickupManager->createPickup(this, effectNS::ENLARGE);
-
-	entityVector.push_back(pickup);
 }
 
 //=============================================================================

--- a/src/pongstar.h
+++ b/src/pongstar.h
@@ -10,7 +10,6 @@
 #include "game.h"
 #include "dataManager.h"
 #include "fontManager.h"
-#include "pickupManager.h"
 #include "textureManager.h"
 #include "messageManager.h"
 #include "image.h"
@@ -26,7 +25,6 @@ private:
 	// Game items
 	DataManager* dataManager;
 	FontManager* fontManager;
-	PickupManager* pickupManager;
 	MessageManager* messageManager;
 
 	TextureManager dividerTexture;


### PR DESCRIPTION
### Changes
- Pickups now spawn randomly along the y-axis in the middle of the screen when a ball collides with a bumper
- Colliding with a bumper on the left half will spawn a pickup which moves in the right direction and vice versa
- Pickups are deleted once they move beyond the sides of the screen
- `pickupManger` shifted into `messageManager` (may have a better way to do this)

