### PR TITLE
Menu

### DIFF
--- a/pongstar.vcxproj
+++ b/pongstar.vcxproj
@@ -80,6 +80,7 @@
     <ClInclude Include="src\constants.h" />
     <ClInclude Include="src\dataManager.h" />
     <ClInclude Include="src\effects.h" />
+    <ClInclude Include="src\menu.h" />
     <ClInclude Include="src\message.h" />
     <ClInclude Include="src\messageManager.h" />
     <ClInclude Include="src\pickup.h" />
@@ -102,6 +103,7 @@
     <ClCompile Include="src\bumper.cpp" />
     <ClCompile Include="src\dataManager.cpp" />
     <ClCompile Include="src\effects.cpp" />
+    <ClCompile Include="src\menu.cpp" />
     <ClCompile Include="src\message.cpp" />
     <ClCompile Include="src\messageManager.cpp" />
     <ClCompile Include="src\pickup.cpp" />

--- a/pongstar.vcxproj
+++ b/pongstar.vcxproj
@@ -95,7 +95,9 @@
     <ClInclude Include="src\paddle.h" />
     <ClInclude Include="src\pickupManager.h" />
     <ClInclude Include="src\pongstar.h" />
+    <ClInclude Include="src\pongstarBase.h" />
     <ClInclude Include="src\random.h" />
+    <ClInclude Include="src\scene.h" />
     <ClInclude Include="src\textureManager.h" />
   </ItemGroup>
   <ItemGroup>
@@ -117,6 +119,7 @@
     <ClCompile Include="src\paddle.cpp" />
     <ClCompile Include="src\pickupManager.cpp" />
     <ClCompile Include="src\pongstar.cpp" />
+    <ClCompile Include="src\pongstarBase.cpp" />
     <ClCompile Include="src\random.cpp" />
     <ClCompile Include="src\textureManager.cpp" />
     <ClCompile Include="src\winmain.cpp" />

--- a/pongstar.vcxproj.filters
+++ b/pongstar.vcxproj.filters
@@ -81,11 +81,10 @@
     <ClInclude Include="src\random.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-<<<<<<< HEAD
     <ClInclude Include="src\effects.h">
-=======
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\menu.h">
->>>>>>> Draw menu
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\scene.h">

--- a/pongstar.vcxproj.filters
+++ b/pongstar.vcxproj.filters
@@ -88,6 +88,12 @@
 >>>>>>> Draw menu
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\scene.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\pongstarBase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\winmain.cpp">
@@ -151,6 +157,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\menu.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\pongstarBase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/pongstar.vcxproj.filters
+++ b/pongstar.vcxproj.filters
@@ -81,7 +81,11 @@
     <ClInclude Include="src\random.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+<<<<<<< HEAD
     <ClInclude Include="src\effects.h">
+=======
+    <ClInclude Include="src\menu.h">
+>>>>>>> Draw menu
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -144,6 +148,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\effects.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\menu.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -14,6 +14,8 @@ Font::Font() {
 	startFrame = 0;
 	endFrame = 127;
 	currentFrame = 0;
+
+	kerning = 0.0f;
 }
 
 Font::~Font() {
@@ -43,6 +45,10 @@ bool Font::loadTextData(std::string fileName) {
 	// convert raw data to proportional data width
 	for (int i = 0; i < sizeof(this->widths) / sizeof(this->widths[0]); i++) {
 		widths[i] = (int)buffer[i * 2];
+
+		if (i == 73) {		// If hit char 'I' frame, increase width by 20
+			widths[i] += 20;
+		}
 	}
 
 	return true;
@@ -54,17 +60,21 @@ void Font::print(int x, int y, std::string text) {
 
 	for (size_t i = 0; i < text.length(); i++) {
 		int frame = (int)text[i] - '!' + 1;
-		if (isdigit(text[i]))
-			frame += 32;
+		frame += 32;
+
+		if (frame == 73) {	// If 'I' frame
+			fx -= 11;
+		}
 
 		setCurrentFrame(frame);
 		setX(fx);
 		setY(fy);
-		draw();		// repeatedly draw each letter 
+		draw();		// repeatedly draw each letter
+		
 		if (widths[frame] == 0)
 			widths[frame] = getWidth();
 
-		fx += widths[frame] * getScale();
+		fx += widths[frame] * getScale() + kerning;
 	}
 }
 
@@ -73,11 +83,13 @@ int Font::getTotalWidth(std::string text) {
 
 	for (size_t i = 0; i < text.length(); i++) {
 		int frame = (int)text[i] - '!' + 1;
-		if (isdigit(text[i]))
-			frame += 32;
+		frame += 32;
 
-		fx += widths[frame] * getScale();
+		if (frame == 73) {	// If 'I' frame
+			fx -= 11;
+		}
 
+		fx += widths[frame] * getScale() + kerning;
 	}
 
 	return (int)fx;

--- a/src/font.h
+++ b/src/font.h
@@ -9,10 +9,14 @@ class Font : public Image {
 private:
 	int widths[256];
 	std::string text;
+	int kerning;	// independent of scale, space between each char
 
 public:
 	Font();
 	~Font();
+
+	void setKerning(int k) { kerning = k; }
+	int getKerning() { return kerning; }
 
 	bool loadTextData(std::string fileName);
 	bool loadTextSprite(TextureManager* texture);

--- a/src/fontManager.cpp
+++ b/src/fontManager.cpp
@@ -23,10 +23,8 @@ FontManager::FontManager(Graphics* g) {
 }
 
 FontManager::FontManager(const FontManager& obj) {
-	// do not need to copy value of graphics,
-	// all fontManagers can have the same pointer to the same graphics object
-	graphics = obj.graphics;	
-	textureManagers = obj.textureManagers;
+	graphics = obj.graphics;				// Use same graphics pointer for all fontManagers
+	textureManagers = obj.textureManagers;	// Use same texture pointers for all fontManagers
 	
 	fontNS::FONT_NAME name;
 	fontNS::FONT_COLOR color;

--- a/src/fontManager.cpp
+++ b/src/fontManager.cpp
@@ -49,6 +49,8 @@ FontManager::FontManager(const FontManager& obj) {
 	}
 }
 
+FontManager::~FontManager() {}
+
 void FontManager::initialize() {
 	fontNS::FONT_NAME name;
 	std::vector<fontNS::FONT_COLOR> colorsVec;

--- a/src/fontManager.cpp
+++ b/src/fontManager.cpp
@@ -16,11 +16,40 @@ const char* colorToString(fontNS::FONT_COLOR c) {
 	}
 }
 
-FontManager::FontManager(Graphics *g) {
+FontManager::FontManager() {}
+
+FontManager::FontManager(Graphics* g) {
 	graphics = g;
 }
 
-FontManager::~FontManager() {}
+FontManager::FontManager(const FontManager& obj) {
+	// do not need to copy value of graphics,
+	// all fontManagers can have the same pointer to the same graphics object
+	graphics = obj.graphics;	
+	textureManagers = obj.textureManagers;
+	
+	fontNS::FONT_NAME name;
+	fontNS::FONT_COLOR color;
+	Font* font;
+	colorFontMap* cfm;
+	colorFontMap* oldCfm;
+
+	for (auto& x : obj.fonts) {
+		cfm = new colorFontMap();
+		name = x.first;
+		oldCfm = x.second;
+
+		for (auto& y : *oldCfm) {
+			font = new Font();
+			color = y.first;
+			*font = *y.second;
+
+			cfm->insert(colorFontPair(color, font));
+		}
+
+		fonts.insert(nameColorsPair(name, cfm));
+	}
+}
 
 void FontManager::initialize() {
 	fontNS::FONT_NAME name;
@@ -58,6 +87,18 @@ void FontManager::initialize() {
 		}
 
 		fonts.insert(nameColorsPair(name, cfm));
+	}
+}
+
+void FontManager::setScale(fontNS::FONT_NAME name, float scale) {
+	for (auto &colorFont : (*fonts[name])) {
+		colorFont.second->setScale(scale);
+	}
+}
+
+void FontManager::setKerning(fontNS::FONT_NAME name, int kerning) {
+	for (auto &colorFont : (*fonts[name])) {
+		colorFont.second->setKerning(kerning);
 	}
 }
 

--- a/src/fontManager.h
+++ b/src/fontManager.h
@@ -45,10 +45,17 @@ private:
 	nameColorsMap fonts;
 	
 public:
+	FontManager();
 	FontManager(Graphics* graphics);
+	FontManager(const FontManager& fm);	// copy constructor
+	//FontManager& operator=(const FontManager& rhs) {};
+
 	~FontManager();
 
 	void initialize();
+
+	void setScale(fontNS::FONT_NAME n, float s);
+	void setKerning(fontNS::FONT_NAME n, int k);
 
 	void print(fontNS::FONT_NAME n, fontNS::FONT_COLOR c, int x, int y, std::string t);
 	int getTotalWidth(fontNS::FONT_NAME n, std::string t);

--- a/src/fontManager.h
+++ b/src/fontManager.h
@@ -48,7 +48,6 @@ public:
 	FontManager();
 	FontManager(Graphics* graphics);
 	FontManager(const FontManager& fm);	// copy constructor
-	//FontManager& operator=(const FontManager& rhs) {};
 
 	~FontManager();
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,6 +1,6 @@
 #include "menu.h"
 
-const char* sceneToString(menuNS::SCENE s) {
+const char* sceneToString(menuNS::SCENE_TYPE s) {
 	switch (s) {
 	case menuNS::CLASSIC:			return "CLASSIC";
 	case menuNS::TIME_ATK:			return "TIME ATTACK";

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,0 +1,72 @@
+#include "menu.h"
+
+const char* sceneToString(menuNS::SCENE s) {
+	switch (s) {
+	case menuNS::CLASSIC:			return "CLASSIC";
+	case menuNS::TIME_ATK:			return "TIME ATTACK";
+	case menuNS::HIGH_SCORES:		return "HIGH SCORES";
+	case menuNS::CREDITS:			return "CREDITS";
+	}
+}
+
+Menu::Menu() {}
+
+Menu::~Menu() {}
+
+void Menu::initialize(FontManager* fm) {
+	// Copy from initialized fm
+	titleFm = new FontManager(*fm);
+	menuFm = new FontManager(*fm);
+
+	items.push_back(menuNS::CLASSIC);
+	items.push_back(menuNS::TIME_ATK);
+	items.push_back(menuNS::HIGH_SCORES);
+	items.push_back(menuNS::CREDITS);
+}
+
+void Menu::update(float frameTime) {
+
+}
+
+void Menu::render() {
+	int count = 0;
+
+	titleFm->setScale(fontNS::SABO_FILLED, 1.0);
+	titleFm->setScale(fontNS::SABO, 1.0);
+
+	titleFm->setKerning(fontNS::SABO_FILLED, -10);
+	titleFm->setKerning(fontNS::SABO, -10);
+
+	int pongstarWidth = titleFm->getTotalWidth(fontNS::SABO_FILLED, "pong") + titleFm->getTotalWidth(fontNS::SABO, "star");
+	int pongX = GAME_WIDTH / 2 - pongstarWidth / 2 - fontNS::CENTER_OFFSET;
+
+	titleFm->print(
+		fontNS::SABO_FILLED,
+		fontNS::WHITE,
+		pongX,
+		menuNS::TITLE_Y_POS,
+		"pong"
+	);
+
+	titleFm->print(
+		fontNS::SABO,
+		fontNS::WHITE,
+		pongX + titleFm->getTotalWidth(fontNS::SABO_FILLED, "pong"),
+		menuNS::TITLE_Y_POS,
+		"star"
+	);
+
+	menuFm->setKerning(fontNS::SABO_FILLED, -4);
+
+	for (std::list<menuNS::SCENE>::iterator it = items.begin(); it != items.end(); ++it) {
+		menuFm->print(
+			fontNS::SABO_FILLED,
+			fontNS::WHITE,
+			GAME_WIDTH / 2 - menuFm->getTotalWidth(fontNS::SABO_FILLED, sceneToString(*it)) / 2,
+			menuNS::MENU_Y_POS + count * menuNS::HEIGHT_BETWEEN_ITEM,
+			sceneToString(*it)	
+		);
+
+		count++;
+	}
+}

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,31 +1,35 @@
 #include "menu.h"
 
-const char* sceneToString(menuNS::SCENE_TYPE s) {
+const char* sceneToString(sceneNS::TYPE s) {
 	switch (s) {
-	case menuNS::CLASSIC:			return "CLASSIC";
-	case menuNS::TIME_ATK:			return "TIME ATTACK";
-	case menuNS::HIGH_SCORES:		return "HIGH SCORES";
-	case menuNS::CREDITS:			return "CREDITS";
+	case sceneNS::CLASSIC:			return "CLASSIC";
+	case sceneNS::TIME_ATK:			return "TIME ATTACK";
+	case sceneNS::HIGH_SCORES:		return "HIGH SCORES";
+	case sceneNS::CREDITS:			return "CREDITS";
 	}
 }
 
-Menu::Menu() {}
+Menu::Menu() {};
+
+Menu::Menu(Input* i, FontManager* fm) {
+	input = i;
+	baseFm = fm;
+}
 
 Menu::~Menu() {}
 
-void Menu::initialize(Input* i, FontManager* fm) {
+void Menu::initialize() {
 	selectedItemIndex = 0;
 	blink = true;
-	input = i;
 
 	// Copy from initialized fm
-	titleFm = new FontManager(*fm);
-	menuFm = new FontManager(*fm);
+	titleFm = new FontManager(*baseFm);
+	menuFm = new FontManager(*baseFm);
 
-	items.push_back(menuNS::CLASSIC);
-	items.push_back(menuNS::TIME_ATK);
-	items.push_back(menuNS::HIGH_SCORES);
-	items.push_back(menuNS::CREDITS);
+	items.push_back(sceneNS::CLASSIC);
+	items.push_back(sceneNS::TIME_ATK);
+	items.push_back(sceneNS::HIGH_SCORES);
+	items.push_back(sceneNS::CREDITS);
 }
 
 void Menu::update(float frameTime) {
@@ -35,6 +39,11 @@ void Menu::update(float frameTime) {
 
 	if (input->wasKeyPressed(DOWN_KEY)) {
 		selectedItemIndex = selectedItemIndex == items.size() - 1 ? 0 : selectedItemIndex + 1;
+	}
+
+	if (input->wasKeyPressed(ENTER_KEY)) {
+		nextSceneType = new sceneNS::TYPE;
+		nextSceneType = &items[selectedItemIndex];
 	}
 
 	if (blinkTimer < menuNS::BLINK_INTERVAL) {

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,14 +1,20 @@
 #ifndef _MENU_H
 #define _MENU_H
 
+#include <vector>
+
+#include "constants.h"
 #include "graphics.h"
+#include "input.h"
 #include "fontManager.h"
-#include <list>
 
 namespace menuNS {
 	const int TITLE_Y_POS = 70;
 	const int MENU_Y_POS = 250;
 	const int HEIGHT_BETWEEN_ITEM = 90;
+	const int DIST_BTWN_MINUS_AND_ITEM = 20;
+	const float BLINK_INTERVAL = 0.2f;
+
 	enum SCENE {
 		CLASSIC, TIME_ATK, HIGH_SCORES, CREDITS
 	};
@@ -18,13 +24,18 @@ class Menu {
 private:
 	FontManager* titleFm;
 	FontManager* menuFm;
-	std::list<menuNS::SCENE> items;
+	std::vector<menuNS::SCENE> items;
+	Input* input;
+	int selectedItemIndex;
+
+	float blinkTimer;
+	bool blink;
 
 public:
 	Menu();
 	~Menu();
 
-	void initialize(FontManager* fm);
+	void initialize(Input *i, FontManager* fm);
 	void update(float frameTime);
 	void render();
 };

--- a/src/menu.h
+++ b/src/menu.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "constants.h"
+#include "scene.h"
 #include "graphics.h"
 #include "input.h"
 #include "fontManager.h"
@@ -14,18 +15,18 @@ namespace menuNS {
 	const int HEIGHT_BETWEEN_ITEM = 90;
 	const int DIST_BTWN_MINUS_AND_ITEM = 20;
 	const float BLINK_INTERVAL = 0.2f;
-
-	enum SCENE_TYPE {
-		CLASSIC, TIME_ATK, HIGH_SCORES, CREDITS
-	};
 }
 
-class Menu {
+class Menu : public Scene {
 private:
+	// Game items
+	Input* input;
+	FontManager* baseFm;
+
+	// Scene items
 	FontManager* titleFm;
 	FontManager* menuFm;
-	std::vector<menuNS::SCENE_TYPE> items;
-	Input* input;
+	std::vector<sceneNS::TYPE> items;
 	int selectedItemIndex;
 
 	float blinkTimer;
@@ -33,11 +34,18 @@ private:
 
 public:
 	Menu();
+	Menu::Menu(Input* i, FontManager* fm);
 	~Menu();
-
-	void initialize(Input *i, FontManager* fm);
+	
+	// Interface
+	void initialize();
 	void update(float frameTime);
+	void ai() {};
+	void collisions() {};
 	void render();
+
+	void releaseAll() {};
+	void resetAll() {};
 };
 
 #endif

--- a/src/menu.h
+++ b/src/menu.h
@@ -15,7 +15,7 @@ namespace menuNS {
 	const int DIST_BTWN_MINUS_AND_ITEM = 20;
 	const float BLINK_INTERVAL = 0.2f;
 
-	enum SCENE {
+	enum SCENE_TYPE {
 		CLASSIC, TIME_ATK, HIGH_SCORES, CREDITS
 	};
 }
@@ -24,7 +24,7 @@ class Menu {
 private:
 	FontManager* titleFm;
 	FontManager* menuFm;
-	std::vector<menuNS::SCENE> items;
+	std::vector<menuNS::SCENE_TYPE> items;
 	Input* input;
 	int selectedItemIndex;
 

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,0 +1,32 @@
+#ifndef _MENU_H
+#define _MENU_H
+
+#include "graphics.h"
+#include "fontManager.h"
+#include <list>
+
+namespace menuNS {
+	const int TITLE_Y_POS = 70;
+	const int MENU_Y_POS = 250;
+	const int HEIGHT_BETWEEN_ITEM = 90;
+	enum SCENE {
+		CLASSIC, TIME_ATK, HIGH_SCORES, CREDITS
+	};
+}
+
+class Menu {
+private:
+	FontManager* titleFm;
+	FontManager* menuFm;
+	std::list<menuNS::SCENE> items;
+
+public:
+	Menu();
+	~Menu();
+
+	void initialize(FontManager* fm);
+	void update(float frameTime);
+	void render();
+};
+
+#endif

--- a/src/messageManager.cpp
+++ b/src/messageManager.cpp
@@ -2,13 +2,9 @@
 
 MessageManager::MessageManager() {}
 
-MessageManager::MessageManager(Game* g, Graphics* graphics, std::vector<Entity*>* ev) {
-	game = g;
+MessageManager::MessageManager(PickupManager* pm, std::vector<Entity*>* ev) {
 	entityVector = ev;
-
-	pickupManager = new PickupManager(graphics);
-
-	entityVector->push_back(pickupManager->createPickup(g, effectNS::BOOST));
+	pickupManager = pm;
 }
 
 MessageManager::~MessageManager() {}
@@ -61,7 +57,7 @@ void MessageManager::dispatch(Message* msg) {
 		} break;
 		case messageNS::PICKUP: {
 			dispatchPickup(msg);
-		}
+		} break;
 	}
 }
 
@@ -83,14 +79,10 @@ void MessageManager::dispatchEffect(Message* msg) {
 }
 
 void MessageManager::dispatchPickup(Message* msg) {
-	Pickup* pickup = pickupManager->randomPickup(game);
-
-	if (msg->getPickupCmd() == messageNS::MOVE_LEFT) {
-		pickup->setVelocity(VECTOR2(-pickupNS::VELOCITY, 0));
-	}
-	else {
-		pickup->setVelocity(VECTOR2(pickupNS::VELOCITY, 0));
-	}
-
-	entityVector->push_back(pickup);
+	Pickup* pickup = pickupManager->randomPickup();
+	pickup->setVelocity(
+		msg->getPickupCmd() == messageNS::MOVE_LEFT ? 
+		VECTOR2(-pickupNS::VELOCITY, 0) :
+		VECTOR2(pickupNS::VELOCITY, 0)
+	);
 }

--- a/src/messageManager.h
+++ b/src/messageManager.h
@@ -1,27 +1,29 @@
-/* In charge of relying messages to the correct entites or components */
+/*	In charge of relying messages to the correct entites or components
+	MessageManager should not store any data
+*/
 
-#ifndef _MESSAGEMANAGER_H
+#ifndef _MESSAGEMANAGER_H	
 #define _MESSAGEMANAGER_H
 
 #include <queue>
 
-#include "game.h"
+#include "pickupManager.h"
 #include "message.h"
 #include "entity.h"
 #include "paddle.h"
 #include "ball.h"
-#include "pickupManager.h"
 
 class MessageManager {
 private:
-	Game* game;
-	PickupManager* pickupManager;
 	std::queue<Message*> messageQueue;
 	std::vector<Entity*>* entityVector;
 
+	// Components
+	PickupManager* pickupManager;
+
 public:
 	MessageManager();
-	MessageManager(Game* g, Graphics* graphics, std::vector<Entity*>* ev);
+	MessageManager(PickupManager* pm, std::vector<Entity*>* ev);
 	~MessageManager();
 
 	void push(Message* msg);
@@ -29,7 +31,7 @@ public:
 
 	void dispatchScore(Message* msg);
 	void dispatchEffect(Message* msg);
-	void dispatchPickup(Message* msg);
+	void dispatchPickup(Message *msg);
 
 	void resolve();
 

--- a/src/messageManager.h
+++ b/src/messageManager.h
@@ -1,8 +1,8 @@
-/*	In charge of relying messages to the correct entites or components
+/*	In charge of relaying messages to the correct entites or components
 	MessageManager should not store any data
 */
 
-#ifndef _MESSAGEMANAGER_H	
+#ifndef _MESSAGEMANAGER_H
 #define _MESSAGEMANAGER_H
 
 #include <queue>
@@ -31,7 +31,7 @@ public:
 
 	void dispatchScore(Message* msg);
 	void dispatchEffect(Message* msg);
-	void dispatchPickup(Message *msg);
+	void dispatchPickup(Message* msg);
 
 	void resolve();
 

--- a/src/pickupManager.cpp
+++ b/src/pickupManager.cpp
@@ -2,9 +2,10 @@
 
 PickupManager::PickupManager() {}
 
-PickupManager::PickupManager(Graphics* graphics) {
-	if (!pickupTexture.initialize(graphics, PICKUP_IMAGE))
-		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing pickup texture"));
+PickupManager::PickupManager(Game* g, TextureManager* pt, std::vector<Entity*>* ev) {
+	game = g;
+	pickupTexture = pt;
+	entityVector = ev;
 }
 
 PickupManager::~PickupManager() {}
@@ -17,30 +18,32 @@ int PickupManager::getRandEffectArrIndex() {
 	return randInt(0, effectDataNS::EFFECT_ARR_SIZE);
 }
 
-Pickup* PickupManager::randomPickup(Game* game) {
+Pickup* PickupManager::randomPickup() {
 	effectNS::EffectData data = effectDataNS::effectArray[getRandEffectArrIndex()];
 	Pickup* pickup = new Pickup(data.effectType, data.frame, data.duration);
 
-	if (!pickup->initialize(game, pickupNS::WIDTH, pickupNS::HEIGHT, pickupNS::NCOLS, &pickupTexture))
+	if (!pickup->initialize(game, pickupNS::WIDTH, pickupNS::HEIGHT, pickupNS::NCOLS, pickupTexture))
 		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing pickup"));
 
 	pickup->setX(GAME_WIDTH / 2 - (pickupNS::WIDTH * pickupNS::SCALE) / 2);
 	pickup->setY((float)getRandYSpawn());
 
+	entityVector->push_back(pickup);
 	return pickup;
 }
 
 // For testing
-Pickup* PickupManager::createPickup(Game* game, effectNS::EFFECT_TYPE et) {
+Pickup* PickupManager::createPickup(effectNS::EFFECT_TYPE et) {
 	effectNS::EffectData data = getPickupData(et);
 	Pickup* pickup = new Pickup(data.effectType, data.frame, data.duration);
 
-	if (!pickup->initialize(game, pickupNS::WIDTH, pickupNS::HEIGHT, pickupNS::NCOLS, &pickupTexture))
+	if (!pickup->initialize(game, pickupNS::WIDTH, pickupNS::HEIGHT, pickupNS::NCOLS, pickupTexture))
 		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing pickup"));
 
 	pickup->setX(GAME_WIDTH / 4);
 	pickup->setY(GAME_HEIGHT / 2 - (pickupNS::HEIGHT * pickupNS::SCALE) / 2);
-
+	
+	entityVector->push_back(pickup);
 	return pickup;
 }
 

--- a/src/pickupManager.h
+++ b/src/pickupManager.h
@@ -6,6 +6,7 @@
 
 #include "random.h"
 #include "game.h"
+#include "gameError.h"
 #include "textureManager.h"
 #include "entity.h"
 #include "pickup.h"

--- a/src/pickupManager.h
+++ b/src/pickupManager.h
@@ -6,9 +6,8 @@
 
 #include "random.h"
 #include "game.h"
-#include "graphics.h"
-#include "gameError.h"
 #include "textureManager.h"
+#include "entity.h"
 #include "pickup.h"
 
 namespace effectDataNS {
@@ -27,22 +26,23 @@ namespace effectDataNS {
 	const int EFFECT_ARR_SIZE = 9;
 }
 
-
 class PickupManager {
 private:
-	TextureManager pickupTexture;
+	Game* game;
+	TextureManager* pickupTexture;
+	std::vector<Entity*>* entityVector;
 
 public:
 	PickupManager();
-	PickupManager(Graphics* graphics);
+	PickupManager(Game* g, TextureManager* pt, std::vector<Entity*>* ev);
 
 	~PickupManager();
 	
 	int getRandYSpawn();
 	int getRandEffectArrIndex();
 
-	Pickup* randomPickup(Game* game);
-	Pickup* createPickup(Game* game, effectNS::EFFECT_TYPE et);
+	Pickup* randomPickup();
+	Pickup* createPickup(effectNS::EFFECT_TYPE et);
 
 	effectNS::EffectData getPickupData(effectNS::EFFECT_TYPE et);
 };

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -33,7 +33,7 @@ void Pongstar::initialize(HWND hwnd) {
 	messageManager = new MessageManager(this, graphics, &entityVector);
 
 	menu = new Menu();
-	menu->initialize(fontManager);
+	menu->initialize(input, fontManager);
 
 	// Textures
 	if (!dividerTexture.initialize(graphics, DIVIDER_IMAGE))

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -7,6 +7,8 @@ const char* textureToString(pongstarNS::TEXTURE t) {
 	case pongstarNS::PADDLE:		return "Paddle";
 	case pongstarNS::DIVIDER:		return "Divider";
 	case pongstarNS::BUMPER:		return "Bumper";
+	case pongstarNS::PICKUPS:		return "Pickups";
+	default:						return "Unable to find string conversion for texture";
 	}
 }
 
@@ -63,7 +65,7 @@ void Pongstar::initialize(HWND hwnd) {
 	if (!divider.initialize(graphics, 0, 0, 0, tmMap[pongstarNS::DIVIDER]))
 		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing divider"));
 
-	ps = new PongstarBase(dataManager, fontManager, messageManager, tmMap, this, input);
+	ps = new PongstarBase(this, input, dataManager, fontManager, tmMap);
 	ps->initialize(divider);
 
 	//this->initializeEntities();

--- a/src/pongstar.cpp
+++ b/src/pongstar.cpp
@@ -7,6 +7,7 @@ const char* textureToString(pongstarNS::TEXTURE t) {
 	case pongstarNS::PADDLE:		return "Paddle";
 	case pongstarNS::DIVIDER:		return "Divider";
 	case pongstarNS::BUMPER:		return "Bumper";
+	case pongstarNS::BORDER:		return "Border";
 	case pongstarNS::PICKUPS:		return "Pickups";
 	default:						return "Unable to find string conversion for texture";
 	}
@@ -16,9 +17,7 @@ const char* textureToString(pongstarNS::TEXTURE t) {
 // Constructor
 //=============================================================================
 Pongstar::Pongstar() {
-	elapsedTime = 0;
-	gameStarted = false;
-	gameState = GAME_STATE::GAME;
+	gameStack = new std::stack<Scene*>;
 }
 
 //=============================================================================
@@ -41,9 +40,6 @@ void Pongstar::initialize(HWND hwnd) {
 	fontManager = new FontManager(graphics);
 	fontManager->initialize();
 
-	menu = new Menu();
-	menu->initialize(input, fontManager);
-
 	TextureManager* tm;
 	pongstarNS::TEXTURE texture;
 
@@ -53,7 +49,7 @@ void Pongstar::initialize(HWND hwnd) {
 		texture = pongstarNS::initTextureVec[i];
 
 		sprintf(textureLocation, "%s%s.png", pongstarNS::TEXTURE_DIRECTORY, textureToString(texture));
-		sprintf(errorMsg, "Erorr initializing %s texture", textureToString(texture));
+		sprintf(errorMsg, "Error initializing %s texture", textureToString(texture));
 
 		if (!tm->initialize(graphics, textureLocation))
 			throw(GameError(gameErrorNS::FATAL_ERROR, errorMsg));
@@ -61,93 +57,39 @@ void Pongstar::initialize(HWND hwnd) {
 		tmMap.insert(std::pair<pongstarNS::TEXTURE, TextureManager*>(texture, tm));
 	}
 
-	// Images
-	if (!divider.initialize(graphics, 0, 0, 0, tmMap[pongstarNS::DIVIDER]))
-		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing divider"));
+	Menu* menu = new Menu(input, fontManager);
+	menu->initialize();
+	gameStack->push(menu);
 
-	ps = new PongstarBase(this, input, dataManager, fontManager, tmMap);
-	ps->initialize(divider);
-
-	//this->initializeEntities();
+	//PongstarBase* ps = new PongstarBase(this, dataManager, fontManager, tmMap);
+	//ps->initialize();
+	//gameStack->push(ps);
 
 	return;
-}
-
-void Pongstar::initializeEntities() {
-	//ControlsJson controls = dataManager->getControlsJson();
-
-	//Paddle* paddle1 = new Paddle(controls.p1, paddleNS::LEFT);
-	//Paddle* paddle2 = new Paddle(controls.p2, paddleNS::RIGHT);
-	//Ball* ball = new Ball();
-	//Bumper* bumper = new Bumper();
-
-	//if (!paddle1->initialize(this, paddleNS::WIDTH, paddleNS::HEIGHT, paddleNS::NCOLS, tmMap[pongstarNS::PADDLE]))
-	//	throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing paddle1"));
-
-	//if (!paddle2->initialize(this, paddleNS::WIDTH, paddleNS::HEIGHT, paddleNS::NCOLS, tmMap[pongstarNS::PADDLE]))
-	//	throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing paddle2"));
-
-	//if (!ball->initialize(this, ballNS::WIDTH, ballNS::HEIGHT, ballNS::NCOLS, tmMap[pongstarNS::BALL]))
-	//	throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing ball"));
-
-	//if (!bumper->initialize(this, bumperNS::WIDTH, bumperNS::HEIGHT, bumperNS::NCOLS, tmMap[pongstarNS::BUMPER]))
-	//	throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing bumper"));
-
-	//paddle1->setX((float)paddleNS::SIDE_SPACE);
-	//paddle1->setY(GAME_HEIGHT / 2 - paddleNS::HEIGHT / 2);
-	//paddle2->setX(GAME_WIDTH - paddleNS::SIDE_SPACE - paddleNS::WIDTH);
-	//paddle2->setY(GAME_HEIGHT / 2 - paddleNS::HEIGHT / 2);
-
-	//ball->setX(GAME_WIDTH / 2 - ballNS::WIDTH / 2);
-	//ball->setY(GAME_HEIGHT / 2 - ballNS::HEIGHT / 2);
-
-	//entityVector.push_back(paddle1);
-	//entityVector.push_back(paddle2);
-	//entityVector.push_back(ball);
-	//entityVector.push_back(bumper);
 }
 
 //=============================================================================
 // Update all game items
 //=============================================================================
 void Pongstar::update() {
-	switch (gameState) {
-	case GAME_STATE::MENU: {
-		menu->update(frameTime);
-	} break;
-	case GAME_STATE::GAME: {
-		ps->update(frameTime);
-		//for (size_t i = 0; i < entityVector.size(); ++i) {
-		//	entityVector[i]->update(frameTime);
+	gameStack->top()->update(frameTime);
 
-		//	if (!entityVector[i]->getActive()) {
-		//		deleteEntityQueue.push(i);
-		//	}
+	if (input->wasKeyPressed(ESC_KEY) && gameStack->size() > 1)
+		gameStack->pop();
 
-		//	if (entityVector[i]->getMessage() != NULL) {
-		//		messageManager->push(entityVector[i]->getMessage());
-		//		entityVector[i]->setMessage(NULL);
-		//	}
-		//}
+	if (gameStack->top()->getNextSceneType() != NULL) {
+		sceneNS::TYPE nextSceneType = *gameStack->top()->getNextSceneType();
+		gameStack->top()->clearNextSceneType();
+		Scene* nextScene;
 
-		//while (deleteEntityQueue.size() > 0) {
-		//	int indexToRemove = deleteEntityQueue.front();
-		//	entityVector.erase(entityVector.begin() + indexToRemove);
-		//	deleteEntityQueue.pop();
-		//}
+		switch (nextSceneType) {
+			case sceneNS::CLASSIC: {
+				nextScene = new PongstarBase(this, dataManager, fontManager, tmMap);
+				nextScene->initialize();
+			} break;
+		}
 
-		//messageManager->resolve();
-
-		//if (input->wasKeyPressed(SPACE_KEY) && !gameStarted) {
-		//	startTime = steady_clock::now();
-		//	gameStarted = true;
-		//}
-
-		//if (gameStarted) {
-		//	steady_clock::time_point presentTime = steady_clock::now();
-		//	elapsedTime = duration_cast<seconds>(presentTime - startTime).count();
-		//}
-	} break;
+		gameStack->push(nextScene);
 	}
 }
 
@@ -160,24 +102,7 @@ void Pongstar::ai() {}
 // Handle collisions
 //=============================================================================
 void Pongstar::collisions() {
-	switch (gameState) {
-	case GAME_STATE::MENU: {
-
-	} break;
-	case GAME_STATE::GAME: {
-		ps->collisions();
-		//VECTOR2 collisionVector;
-
-		//for (size_t i = 0; i < entityVector.size(); ++i) {
-		//	for (size_t j = 0; j < entityVector.size(); ++j) {
-		//		if (entityVector[i]->getId() != entityVector[j]->getId()) {
-		//			entityVector[i]->collidesWith(*entityVector[j], collisionVector);
-		//		}
-		//	}
-		//}
-	} break;
-	}
-
+	gameStack->top()->collisions();
 }
 
 //=============================================================================
@@ -185,49 +110,7 @@ void Pongstar::collisions() {
 //=============================================================================
 void Pongstar::render() {
 	graphics->spriteBegin();                // begin drawing sprites
-	switch (gameState) {
-	case GAME_STATE::MENU: {
-		menu->render();
-	} break;
-	case GAME_STATE::GAME: {
-		ps->render();
-	/*	divider.draw();
-
-		for (size_t i = 0; i < entityVector.size(); ++i) {
-			entityVector[i]->draw();
-		}
-
-		border.draw();
-
-		std::string timeLeft = std::to_string(TIME_PER_GAME - elapsedTime);
-		std::string leftPaddleScore = std::to_string(messageManager->getPaddle(paddleNS::LEFT)->getScore());
-		std::string rightPaddleScore = std::to_string(messageManager->getPaddle(paddleNS::RIGHT)->getScore());
-
-		fontManager->print(
-			fontNS::SABO_FILLED,
-			elapsedTime > 50 ? fontNS::RED : fontNS::WHITE,
-			GAME_WIDTH / 2 - fontManager->getTotalWidth(fontNS::SABO_FILLED, timeLeft) / 2 - fontNS::CENTER_OFFSET,
-			HUD_Y_POS,
-			timeLeft
-		);
-
-		fontManager->print(
-			fontNS::SABO_FILLED,
-			fontNS::ORANGE,
-			GAME_WIDTH / 4 - fontManager->getTotalWidth(fontNS::SABO_FILLED, leftPaddleScore) / 2 - fontNS::CENTER_OFFSET,
-			HUD_Y_POS,
-			leftPaddleScore
-		);
-
-		fontManager->print(
-			fontNS::SABO_FILLED,
-			fontNS::BLUE,
-			GAME_WIDTH / 4 * 3 - fontManager->getTotalWidth(fontNS::SABO_FILLED, rightPaddleScore) / 2 - fontNS::CENTER_OFFSET,
-			HUD_Y_POS,
-			rightPaddleScore
-		);*/
-	} break;
-
+	gameStack->top()->render();
 	graphics->spriteEnd();                  // end drawing sprites
 }
 

--- a/src/pongstar.h
+++ b/src/pongstar.h
@@ -2,32 +2,18 @@
 #define _PONGSTAR_H
 #define _WIN32_LEAN_AND_MEAN
 
-#include <vector>
-#include <queue>
 #include <stack>
-#include <chrono>
-#include <unordered_map>
 
 #include "game.h"
 #include "dataManager.h"
 #include "fontManager.h"
 #include "textureManager.h"
-#include "messageManager.h"
-#include "image.h"
-
-#include "paddle.h"
-#include "ball.h"
-#include "bumper.h"
 
 #include "scene.h"
 #include "menu.h"
 #include "pongstarBase.h"
 
 using namespace std::chrono;
-
-enum GAME_STATE {
-	MENU, GAME
-};
 
 class Pongstar : public Game {
 private:
@@ -36,21 +22,7 @@ private:
 	FontManager* fontManager;
 	TextureManagerMap tmMap;
 
-	Image border;
-	Image divider;
-
-	std::vector<Entity*> entityVector;
-	std::queue<int> deleteEntityQueue;
-
-	steady_clock::time_point startTime;
-	int elapsedTime;
-	bool gameStarted;
-
-	Menu* menu;
-
-	GAME_STATE gameState;
-	std::stack<Scene> gameStack;
-	PongstarBase* ps;
+	std::stack<Scene*>* gameStack;
 
 public:
 	// Constructor
@@ -61,7 +33,6 @@ public:
 
 	// Initialize the game
 	void initialize(HWND hwnd);
-	void initializeEntities();
 
 	void update();      // must override pure virtual from Game
 	void ai();          // "

--- a/src/pongstar.h
+++ b/src/pongstar.h
@@ -17,7 +17,13 @@
 #include "ball.h"
 #include "bumper.h"
 
+#include "menu.h"
+
 using namespace std::chrono;
+
+enum GAME_STATE {
+	MENU, GAME
+};
 
 class Pongstar : public Game {
 private:
@@ -41,6 +47,10 @@ private:
 	steady_clock::time_point startTime;
 	int elapsedTime;
 	bool gameStarted;
+
+	Menu* menu;
+
+	GAME_STATE gameState;
 
 public:
 	// Constructor

--- a/src/pongstar.h
+++ b/src/pongstar.h
@@ -4,7 +4,9 @@
 
 #include <vector>
 #include <queue>
+#include <stack>
 #include <chrono>
+#include <unordered_map>
 
 #include "game.h"
 #include "dataManager.h"
@@ -17,7 +19,9 @@
 #include "ball.h"
 #include "bumper.h"
 
+#include "scene.h"
 #include "menu.h"
+#include "pongstarBase.h"
 
 using namespace std::chrono;
 
@@ -30,13 +34,7 @@ private:
 	// Game items
 	DataManager* dataManager;
 	FontManager* fontManager;
-	MessageManager* messageManager;
-
-	TextureManager ballTexture;
-	TextureManager paddleTexture;
-	TextureManager bumperTexture;
-	TextureManager borderTexture;
-	TextureManager dividerTexture;
+	TextureManagerMap tmMap;
 
 	Image border;
 	Image divider;
@@ -51,6 +49,8 @@ private:
 	Menu* menu;
 
 	GAME_STATE gameState;
+	std::stack<Scene> gameStack;
+	PongstarBase* ps;
 
 public:
 	// Constructor

--- a/src/pongstarBase.cpp
+++ b/src/pongstarBase.cpp
@@ -1,0 +1,150 @@
+#include "pongstarBase.h"
+
+PongstarBase::PongstarBase(DataManager* dm, FontManager* fm, MessageManager* mm, TextureManagerMap t, Game* g, Input* i) {
+	messageManager = mm;
+	fontManager = fm;
+	dataManager = dm;
+	tmMap = t;
+	game = g;
+	input = i;
+}
+
+PongstarBase::~PongstarBase() {}
+
+void PongstarBase::initialize(Image d) {
+	divider = d;
+	
+	initializeEntities();
+
+	messageManager = new MessageManager(this, graphics, &entityVector);
+}
+
+void PongstarBase::initializeEntities() {
+	ControlsJson controls = dataManager->getControlsJson();
+
+	Paddle* paddle1 = new Paddle(controls.p1, paddleNS::LEFT);
+	Paddle* paddle2 = new Paddle(controls.p2, paddleNS::RIGHT);
+	Ball* ball = new Ball();
+	Bumper* bumper = new Bumper();
+
+	if (!paddle1->initialize(game, paddleNS::WIDTH, paddleNS::HEIGHT, paddleNS::NCOLS, tmMap[pongstarNS::PADDLE]))
+		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing paddle1"));
+
+	if (!paddle2->initialize(game, paddleNS::WIDTH, paddleNS::HEIGHT, paddleNS::NCOLS, tmMap[pongstarNS::PADDLE]))
+		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing paddle2"));
+
+	if (!ball->initialize(game, ballNS::WIDTH, ballNS::HEIGHT, ballNS::NCOLS, tmMap[pongstarNS::BALL]))
+		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing ball"));
+
+	if (!bumper->initialize(game, bumperNS::WIDTH, bumperNS::HEIGHT, bumperNS::NCOLS, tmMap[pongstarNS::BUMPER]))
+		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing bumper"));
+
+	paddle1->setX((float)paddleNS::SIDE_SPACE);
+	paddle1->setY(GAME_HEIGHT / 2 - paddleNS::HEIGHT / 2);
+	paddle2->setX(GAME_WIDTH - paddleNS::SIDE_SPACE - paddleNS::WIDTH);
+	paddle2->setY(GAME_HEIGHT / 2 - paddleNS::HEIGHT / 2);
+
+	ball->setX(GAME_WIDTH / 2 - ballNS::WIDTH / 2);
+	ball->setY(GAME_HEIGHT / 2 - ballNS::HEIGHT / 2);
+
+	entityVector.push_back(paddle1);
+	entityVector.push_back(paddle2);
+	entityVector.push_back(ball);
+	entityVector.push_back(bumper);
+}
+
+void PongstarBase::update(float frameTime) {
+	for (size_t i = 0; i < entityVector.size(); ++i) {
+		entityVector[i]->update(frameTime);
+
+		if (!entityVector[i]->getActive()) {
+			deleteEntityQueue.push(i);
+		}
+
+		if (entityVector[i]->getMessage() != NULL) {
+			messageManager->push(entityVector[i]->getMessage());
+			entityVector[i]->setMessage(NULL);
+		}
+	}
+
+	while (deleteEntityQueue.size() > 0) {
+		int indexToRemove = deleteEntityQueue.front();
+		entityVector.erase(entityVector.begin() + indexToRemove);
+		deleteEntityQueue.pop();
+	}
+
+	messageManager->resolve();
+
+	if (input->wasKeyPressed(SPACE_KEY) && !gameStarted) {
+		startTime = steady_clock::now();
+		gameStarted = true;
+	}
+
+	if (gameStarted) {
+		steady_clock::time_point presentTime = steady_clock::now();
+		elapsedTime = duration_cast<seconds>(presentTime - startTime).count();
+	}
+}
+
+void PongstarBase::ai() {
+
+}
+
+void PongstarBase::collisions() {
+	VECTOR2 collisionVector;
+
+	for (size_t i = 0; i < entityVector.size(); ++i) {
+		for (size_t j = 0; j < entityVector.size(); ++j) {
+			if (entityVector[i]->getId() != entityVector[j]->getId()) {
+				entityVector[i]->collidesWith(*entityVector[j], collisionVector);
+			}
+		}
+	}
+}
+
+void PongstarBase::render() {
+	divider.draw();
+
+	for (size_t i = 0; i < entityVector.size(); ++i) {
+		entityVector[i]->draw();
+	}
+
+	std::string timeLeft = std::to_string(TIME_PER_GAME - elapsedTime);
+	std::string leftPaddleScore = std::to_string(messageManager->getPaddle(paddleNS::LEFT)->getScore());
+	std::string rightPaddleScore = std::to_string(messageManager->getPaddle(paddleNS::RIGHT)->getScore());
+
+	printf("right %i\n", messageManager->getPaddle(paddleNS::RIGHT)->getScore());
+	printf("left %i\n", messageManager->getPaddle(paddleNS::LEFT)->getScore());
+
+	fontManager->print(
+		fontNS::SABO_FILLED,
+		elapsedTime > 50 ? fontNS::RED : fontNS::WHITE,
+		GAME_WIDTH / 2 - fontManager->getTotalWidth(fontNS::SABO_FILLED, timeLeft) / 2 - fontNS::CENTER_OFFSET,
+		HUD_Y_POS,
+		timeLeft
+		);
+
+	fontManager->print(
+		fontNS::SABO_FILLED,
+		fontNS::ORANGE,
+		GAME_WIDTH / 4 - fontManager->getTotalWidth(fontNS::SABO_FILLED, leftPaddleScore) / 2 - fontNS::CENTER_OFFSET,
+		HUD_Y_POS,
+		leftPaddleScore
+		);
+
+	fontManager->print(
+		fontNS::SABO_FILLED,
+		fontNS::BLUE,
+		GAME_WIDTH / 4 * 3 - fontManager->getTotalWidth(fontNS::SABO_FILLED, rightPaddleScore) / 2 - fontNS::CENTER_OFFSET,
+		HUD_Y_POS,
+		rightPaddleScore
+		);
+}
+
+void PongstarBase::releaseAll() {
+
+}
+
+void PongstarBase::resetAll() {
+
+}

--- a/src/pongstarBase.cpp
+++ b/src/pongstarBase.cpp
@@ -1,8 +1,7 @@
 #include "pongstarBase.h"
 
-PongstarBase::PongstarBase(Game* g, Input* i, DataManager* dm, FontManager* fm, TextureManagerMap t) {
+PongstarBase::PongstarBase(Game* g, DataManager* dm, FontManager* fm, TextureManagerMap t) {
 	game = g;
-	input = i;
 	dataManager = dm;
 	fontManager = fm;
 	tmMap = t;
@@ -10,11 +9,15 @@ PongstarBase::PongstarBase(Game* g, Input* i, DataManager* dm, FontManager* fm, 
 
 PongstarBase::~PongstarBase() {}
 
-void PongstarBase::initialize(Image d) {
-	divider = d;
-
+void PongstarBase::initialize() {
 	pickupManager = new PickupManager(game, tmMap[pongstarNS::PICKUPS], &entityVector);
 	messageManager = new MessageManager(pickupManager, &entityVector);
+
+	if (!divider.initialize(game->getGraphics(), 0, 0, 0, tmMap[pongstarNS::DIVIDER]))
+		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing divider"));
+
+	if (!border.initialize(game->getGraphics(), 0, 0, 0, tmMap[pongstarNS::BORDER]))
+		throw(GameError(gameErrorNS::FATAL_ERROR, "Error initializing border"));
 
 	initializeEntities();
 }
@@ -57,6 +60,8 @@ void PongstarBase::initializeEntities() {
 }
 
 void PongstarBase::update(float frameTime) {
+	Input* input = game->getInput();
+
 	for (size_t i = 0; i < entityVector.size(); ++i) {
 		entityVector[i]->update(frameTime);
 
@@ -111,6 +116,8 @@ void PongstarBase::render() {
 	for (size_t i = 0; i < entityVector.size(); ++i) {
 		entityVector[i]->draw();
 	}
+
+	border.draw();
 
 	std::string timeLeft = std::to_string(TIME_PER_GAME - elapsedTime);
 	std::string leftPaddleScore = std::to_string(messageManager->getPaddle(paddleNS::LEFT)->getScore());

--- a/src/pongstarBase.cpp
+++ b/src/pongstarBase.cpp
@@ -1,22 +1,22 @@
 #include "pongstarBase.h"
 
-PongstarBase::PongstarBase(DataManager* dm, FontManager* fm, MessageManager* mm, TextureManagerMap t, Game* g, Input* i) {
-	messageManager = mm;
-	fontManager = fm;
-	dataManager = dm;
-	tmMap = t;
+PongstarBase::PongstarBase(Game* g, Input* i, DataManager* dm, FontManager* fm, TextureManagerMap t) {
 	game = g;
 	input = i;
+	dataManager = dm;
+	fontManager = fm;
+	tmMap = t;
 }
 
 PongstarBase::~PongstarBase() {}
 
 void PongstarBase::initialize(Image d) {
 	divider = d;
-	
-	initializeEntities();
 
-	messageManager = new MessageManager(this, graphics, &entityVector);
+	pickupManager = new PickupManager(game, tmMap[pongstarNS::PICKUPS], &entityVector);
+	messageManager = new MessageManager(pickupManager, &entityVector);
+
+	initializeEntities();
 }
 
 void PongstarBase::initializeEntities() {
@@ -51,6 +51,9 @@ void PongstarBase::initializeEntities() {
 	entityVector.push_back(paddle2);
 	entityVector.push_back(ball);
 	entityVector.push_back(bumper);
+
+	// Testing sprite effect
+	pickupManager->createPickup(effectNS::ENLARGE);
 }
 
 void PongstarBase::update(float frameTime) {

--- a/src/pongstarBase.h
+++ b/src/pongstarBase.h
@@ -24,7 +24,7 @@
 using namespace std::chrono;
 
 namespace pongstarNS {
-	enum TEXTURE { BALL, PADDLE, DIVIDER, BUMPER, PICKUPS };
+	enum TEXTURE { BALL, PADDLE, DIVIDER, BUMPER, BORDER, PICKUPS };
 	const char TEXTURE_DIRECTORY[] = "sprites\\";
 
 	const std::vector<TEXTURE> initTextureVec = {
@@ -32,6 +32,7 @@ namespace pongstarNS {
 		TEXTURE::PADDLE,
 		TEXTURE::DIVIDER,
 		TEXTURE::BUMPER,
+		TEXTURE::BORDER,
 		TEXTURE::PICKUPS
 	};
 }
@@ -42,30 +43,32 @@ class PongstarBase : public Scene {
 private:
 	// Game items
 	Game* game;
-	Input* input;
 	FontManager* fontManager;
 	DataManager* dataManager;
 	TextureManagerMap tmMap;
 
+	// Scene items
 	MessageManager* messageManager;
 	PickupManager* pickupManager;
-	Image divider;
-
 	std::vector<Entity*> entityVector;
 	std::queue<int> deleteEntityQueue;
+
+	// Other sprites that are not entities
+	Image divider;
+	Image border;
 
 	steady_clock::time_point startTime;
 	int elapsedTime;
 	bool gameStarted;
 
 public:
-	PongstarBase(Game* g, Input* i, DataManager* dm, FontManager* fm, TextureManagerMap t);
+	PongstarBase(Game* g, DataManager* dm, FontManager* fm, TextureManagerMap t);
 	~PongstarBase();
 
-	virtual void initialize(Image d);
 	void initializeEntities();
 
 	// Interface
+	virtual void initialize();	// initialize base pongstar items
 	virtual void update(float frameTime);
 	virtual void ai();
 	virtual void collisions();

--- a/src/pongstarBase.h
+++ b/src/pongstarBase.h
@@ -1,0 +1,76 @@
+#ifndef _PONGSTARBASE_H
+#define _PONGSTARBASE_H
+#define _WIN32_LEAN_AND_MEAN
+
+#include <vector>
+#include <queue>
+#include <stack>
+#include <chrono>
+
+#include "gameError.h"
+#include "game.h"
+#include "dataManager.h"
+#include "fontManager.h"
+#include "textureManager.h"
+#include "messageManager.h"
+#include "image.h"
+
+#include "paddle.h"
+#include "ball.h"
+#include "bumper.h"
+#include "scene.h"
+
+using namespace std::chrono;
+
+
+namespace pongstarNS {
+	enum TEXTURE { BALL, PADDLE, DIVIDER, BUMPER };
+	const char TEXTURE_DIRECTORY[] = "sprites\\";
+
+	const std::vector<TEXTURE> initTextureVec = {
+		TEXTURE::BALL,
+		TEXTURE::PADDLE,
+		TEXTURE::DIVIDER,
+		TEXTURE::BUMPER
+	};
+}
+
+typedef std::unordered_map<pongstarNS::TEXTURE, TextureManager*> TextureManagerMap;
+
+class PongstarBase : public Scene {
+private:
+	// Game items
+	MessageManager* messageManager;
+	FontManager* fontManager;
+	DataManager* dataManager;
+	TextureManagerMap tmMap;
+	Game* game;
+	Input* input;
+
+	Image divider;
+
+	std::vector<Entity*> entityVector;
+	std::queue<int> deleteEntityQueue;
+
+	steady_clock::time_point startTime;
+	int elapsedTime;
+	bool gameStarted;
+
+public:
+	PongstarBase(DataManager* dm, FontManager* fm, MessageManager* mm, TextureManagerMap t, Game* g, Input* i);
+	~PongstarBase();
+
+	virtual void initialize(Image d);
+	void initializeEntities();
+
+	// Interface
+	virtual void update(float frameTime);
+	virtual void ai();
+	virtual void collisions();
+	virtual void render();
+
+	virtual void releaseAll();
+	virtual void resetAll();
+};
+
+#endif

--- a/src/pongstarBase.h
+++ b/src/pongstarBase.h
@@ -7,12 +7,13 @@
 #include <stack>
 #include <chrono>
 
-#include "gameError.h"
 #include "game.h"
+#include "gameError.h"
 #include "dataManager.h"
 #include "fontManager.h"
 #include "textureManager.h"
 #include "messageManager.h"
+#include "pickupManager.h"
 #include "image.h"
 
 #include "paddle.h"
@@ -22,16 +23,16 @@
 
 using namespace std::chrono;
 
-
 namespace pongstarNS {
-	enum TEXTURE { BALL, PADDLE, DIVIDER, BUMPER };
+	enum TEXTURE { BALL, PADDLE, DIVIDER, BUMPER, PICKUPS };
 	const char TEXTURE_DIRECTORY[] = "sprites\\";
 
 	const std::vector<TEXTURE> initTextureVec = {
 		TEXTURE::BALL,
 		TEXTURE::PADDLE,
 		TEXTURE::DIVIDER,
-		TEXTURE::BUMPER
+		TEXTURE::BUMPER,
+		TEXTURE::PICKUPS
 	};
 }
 
@@ -40,13 +41,14 @@ typedef std::unordered_map<pongstarNS::TEXTURE, TextureManager*> TextureManagerM
 class PongstarBase : public Scene {
 private:
 	// Game items
-	MessageManager* messageManager;
+	Game* game;
+	Input* input;
 	FontManager* fontManager;
 	DataManager* dataManager;
 	TextureManagerMap tmMap;
-	Game* game;
-	Input* input;
 
+	MessageManager* messageManager;
+	PickupManager* pickupManager;
 	Image divider;
 
 	std::vector<Entity*> entityVector;
@@ -57,7 +59,7 @@ private:
 	bool gameStarted;
 
 public:
-	PongstarBase(DataManager* dm, FontManager* fm, MessageManager* mm, TextureManagerMap t, Game* g, Input* i);
+	PongstarBase(Game* g, Input* i, DataManager* dm, FontManager* fm, TextureManagerMap t);
 	~PongstarBase();
 
 	virtual void initialize(Image d);

--- a/src/scene.h
+++ b/src/scene.h
@@ -3,10 +3,22 @@
 #ifndef _SCENE_H
 #define _SCENE_H
 
+namespace sceneNS {
+	enum TYPE {
+		CLASSIC, TIME_ATK, HIGH_SCORES, CREDITS
+	};
+}
+
 class Scene {
+protected:
+	sceneNS::TYPE* nextSceneType = NULL;
 public:
+	sceneNS::TYPE* getNextSceneType() { return nextSceneType; }
+	void clearNextSceneType() { nextSceneType = NULL; }
+
 	virtual ~Scene() {}
 
+	virtual void initialize() = 0;
 	virtual void update(float frameTime) = 0;
 	virtual void ai() = 0;
 	virtual void collisions() = 0;

--- a/src/scene.h
+++ b/src/scene.h
@@ -1,0 +1,19 @@
+// Interface class for implementing scenes
+
+#ifndef _SCENE_H
+#define _SCENE_H
+
+class Scene {
+public:
+	virtual ~Scene() {}
+
+	virtual void update(float frameTime) = 0;
+	virtual void ai() = 0;
+	virtual void collisions() = 0;
+	virtual void render() = 0;
+
+	virtual void releaseAll() = 0;
+	virtual void resetAll() = 0;
+};
+
+#endif

--- a/src/timeAttack.h
+++ b/src/timeAttack.h
@@ -1,0 +1,4 @@
+#ifndef _TIMEATTACK_H
+#define _TIMEATTACK_H
+
+#endif


### PR DESCRIPTION
### Scene as view layer
Split view layers into `scenes`. Each `scene` will be implemented using a `scene` interface. `Classic` will be one scene. `Time Attack` will be another scene. Same goes for the rest of the screens, An interface implementation allows us to use a `std::stack<Scene>` for the rendering of our game in `pongstar.cpp`.

### Menu
Menu is drawn to avoid additional loading of sprites. `FontManager` now supports duplication of itself to reduce initialization of textures to increase performance. Multiple fontManagers are needed if the same font needs to be of different scale or kerning on the same page.

Most of the code is just re-organizing stuff.  I have also move `pickupManager` to be owned by `pongstar` and passing a pointer of it to `messageManager`. Textures are now dynamically loaded and passed to their respective scenes.

### Next up
`pongstarbase.cpp` will be used as the base class to create `time_atk` and `classic` modes.